### PR TITLE
fix #4 - expected console.error in tests

### DIFF
--- a/src/__tests__/labs/ViewLab.test.tsx
+++ b/src/__tests__/labs/ViewLab.test.tsx
@@ -21,6 +21,7 @@ import Lab from '../../shared/model/Lab'
 import Patient from '../../shared/model/Patient'
 import Permissions from '../../shared/model/Permissions'
 import { RootState } from '../../shared/store'
+import { expectOneConsoleError } from '../test-utils/console.utils'
 
 const mockStore = createMockStore<RootState, any>([thunk])
 
@@ -196,6 +197,7 @@ describe('View Lab', () => {
       const { wrapper } = await setup(expectedLab, [Permissions.ViewLab, Permissions.CompleteLab])
 
       const expectedError = { message: 'some message', result: 'some result feedback' } as LabError
+      expectOneConsoleError(expectedError)
       jest.spyOn(validateUtil, 'validateLabComplete').mockReturnValue(expectedError)
 
       const completeButton = wrapper.find(Button).at(1)

--- a/src/__tests__/labs/hooks/useCompleteLab.test.ts
+++ b/src/__tests__/labs/hooks/useCompleteLab.test.ts
@@ -5,6 +5,7 @@ import { LabError } from '../../../labs/utils/validate-lab'
 import * as validateLabUtils from '../../../labs/utils/validate-lab'
 import LabRepository from '../../../shared/db/LabRepository'
 import Lab from '../../../shared/model/Lab'
+import { expectOneConsoleError } from '../../test-utils/console.utils'
 import executeMutation from '../../test-utils/use-mutation.util'
 
 describe('Use Complete lab', () => {
@@ -44,6 +45,7 @@ describe('Use Complete lab', () => {
       result: 'some result error message',
     } as LabError
 
+    expectOneConsoleError(expectedLabError)
     jest.spyOn(validateLabUtils, 'validateLabComplete').mockReturnValue(expectedLabError)
 
     await act(async () => {

--- a/src/__tests__/labs/hooks/useRequestLab.test.ts
+++ b/src/__tests__/labs/hooks/useRequestLab.test.ts
@@ -5,6 +5,7 @@ import * as validateLabRequest from '../../../labs/utils/validate-lab'
 import { LabError } from '../../../labs/utils/validate-lab'
 import LabRepository from '../../../shared/db/LabRepository'
 import Lab from '../../../shared/model/Lab'
+import { expectOneConsoleError } from '../../test-utils/console.utils'
 import executeMutation from '../../test-utils/use-mutation.util'
 
 describe('Use Request lab', () => {
@@ -45,6 +46,7 @@ describe('Use Request lab', () => {
       type: 'error type',
     } as LabError
 
+    expectOneConsoleError(expectedError)
     jest.spyOn(validateLabRequest, 'validateLabRequest').mockReturnValue(expectedError)
 
     await act(async () => {

--- a/src/__tests__/labs/requests/NewLabRequest.test.tsx
+++ b/src/__tests__/labs/requests/NewLabRequest.test.tsx
@@ -19,6 +19,7 @@ import PatientRepository from '../../../shared/db/PatientRepository'
 import Lab from '../../../shared/model/Lab'
 import Patient from '../../../shared/model/Patient'
 import { RootState } from '../../../shared/store'
+import { expectOneConsoleError } from '../../test-utils/console.utils'
 
 const mockStore = createMockStore<RootState, any>([thunk])
 describe('New Lab Request', () => {
@@ -112,6 +113,7 @@ describe('New Lab Request', () => {
       type: 'some type error',
     } as LabError
 
+    expectOneConsoleError(error)
     jest.spyOn(validationUtil, 'validateLabRequest').mockReturnValue(error)
 
     it('should display errors', async () => {

--- a/src/__tests__/patients/hooks/useAddCareGoal.test.tsx
+++ b/src/__tests__/patients/hooks/useAddCareGoal.test.tsx
@@ -5,6 +5,7 @@ import PatientRepository from '../../../shared/db/PatientRepository'
 import CareGoal, { CareGoalStatus, CareGoalAchievementStatus } from '../../../shared/model/CareGoal'
 import Patient from '../../../shared/model/Patient'
 import * as uuid from '../../../shared/util/uuid'
+import { expectOneConsoleError } from '../../test-utils/console.utils'
 import executeMutation from '../../test-utils/use-mutation.util'
 
 describe('use add care goal', () => {
@@ -59,8 +60,9 @@ describe('use add care goal', () => {
     const expectedError = {
       message: 'patient.careGoal.error.unableToAdd',
       description: 'some error',
-    }
-    jest.spyOn(validateCareGoal, 'default').mockReturnValue(expectedError as CareGoalError)
+    } as CareGoalError
+    expectOneConsoleError(expectedError)
+    jest.spyOn(validateCareGoal, 'default').mockReturnValue(expectedError)
     jest.spyOn(PatientRepository, 'saveOrUpdate')
 
     try {

--- a/src/__tests__/patients/hooks/useAddCarePlan.test.tsx
+++ b/src/__tests__/patients/hooks/useAddCarePlan.test.tsx
@@ -5,6 +5,7 @@ import PatientRepository from '../../../shared/db/PatientRepository'
 import CarePlan, { CarePlanIntent, CarePlanStatus } from '../../../shared/model/CarePlan'
 import Patient from '../../../shared/model/Patient'
 import * as uuid from '../../../shared/util/uuid'
+import { expectOneConsoleError } from '../../test-utils/console.utils'
 import executeMutation from '../../test-utils/use-mutation.util'
 
 describe('use add care plan', () => {
@@ -45,8 +46,12 @@ describe('use add care plan', () => {
   })
 
   it('should throw an error if validation fails', async () => {
-    const expectedError = { message: 'patient.carePlan.error.unableToAdd', title: 'some error' }
-    jest.spyOn(validateCarePlan, 'default').mockReturnValue(expectedError as CarePlanError)
+    const expectedError = {
+      message: 'patient.carePlan.error.unableToAdd',
+      title: 'some error',
+    } as CarePlanError
+    expectOneConsoleError(expectedError)
+    jest.spyOn(validateCarePlan, 'default').mockReturnValue(expectedError)
     jest.spyOn(PatientRepository, 'saveOrUpdate')
 
     try {

--- a/src/__tests__/patients/hooks/useAddPatientDiagnosis.test.tsx
+++ b/src/__tests__/patients/hooks/useAddPatientDiagnosis.test.tsx
@@ -6,6 +6,7 @@ import PatientRepository from '../../../shared/db/PatientRepository'
 import Diagnosis, { DiagnosisStatus } from '../../../shared/model/Diagnosis'
 import Patient from '../../../shared/model/Patient'
 import * as uuid from '../../../shared/util/uuid'
+import { expectOneConsoleError } from '../../test-utils/console.utils'
 import executeMutation from '../../test-utils/use-mutation.util'
 
 describe('use add diagnosis', () => {
@@ -16,6 +17,7 @@ describe('use add diagnosis', () => {
 
   it('should throw an error if diagnosis validation fails', async () => {
     const expectedError = { name: 'some error' }
+    expectOneConsoleError(expectedError as Error)
     jest.spyOn(validateDiagnosis, 'default').mockReturnValue(expectedError)
     jest.spyOn(PatientRepository, 'saveOrUpdate')
 

--- a/src/__tests__/test-utils/console.utils.ts
+++ b/src/__tests__/test-utils/console.utils.ts
@@ -1,0 +1,5 @@
+export function expectOneConsoleError(expected: Error) {
+  jest.spyOn(console, 'error').mockImplementationOnce((actual) => {
+    expect(actual).toEqual(expected)
+  })
+}


### PR DESCRIPTION
first wave of tests that were easy to modify to expect the console.error

I didn't want to modify global config for the `spyOn`.. but ideas can be discussed 😺 