### PR TITLE
fix(test): improve DatePickerWithLabelFormGroup

### DIFF
--- a/src/__tests__/shared/components/input/DatePickerWithLabelFormGroup.test.tsx
+++ b/src/__tests__/shared/components/input/DatePickerWithLabelFormGroup.test.tsx
@@ -35,23 +35,28 @@ describe('date picker with label form group', () => {
       )
       expect(screen.getByRole('textbox')).toBeDisabled()
     })
-    describe('change handler', () => {
-      it('should call the change handler on change', () => {
-        render(
+  })
+
+  describe('change handler', () => {
+    it('should call the change handler on change', () => {
+      const TestComponent = () => {
+        const [value, setValue] = React.useState(new Date('01/01/2019'))
+        return (
           <DatePickerWithLabelFormGroup
             name="stardate3333"
             label="stardate3333"
-            value={new Date('01/01/2019')}
+            value={value}
             isEditable
-            onChange={jest.fn()}
-          />,
+            onChange={setValue}
+          />
         )
-        const datepickerInput = screen.getByRole('textbox')
+      }
+      render(<TestComponent />)
+      const datepickerInput = screen.getByRole('textbox')
 
-        expect(datepickerInput).toHaveDisplayValue(['01/01/2019'])
-        userEvent.type(datepickerInput, '{selectall}12/25/2021')
-        expect(datepickerInput).toHaveDisplayValue(['12/25/2021'])
-      })
+      expect(datepickerInput).toHaveDisplayValue(['01/01/2019'])
+      userEvent.type(datepickerInput, '{selectall}12/25/2021{enter}')
+      expect(datepickerInput).toHaveDisplayValue(['12/25/2021'])
     })
   })
 })


### PR DESCRIPTION
* #194 workaround for 'NaN is an invalid value' console.error by pressing {enter}
* use controlled form with real onChange to test changed values