### PR TITLE
test(viewincidentdetails.test.tsx): add back deleted tests using RTL

### DIFF
--- a/src/__tests__/incidents/view/ViewIncidentDetails.test.tsx
+++ b/src/__tests__/incidents/view/ViewIncidentDetails.test.tsx
@@ -13,6 +13,7 @@ import Permissions from '../../../shared/model/Permissions'
 
 describe('View Incident Details', () => {
   const expectedDate = new Date(2020, 5, 1, 19, 48)
+  const reportedDate = new Date(2020, 5, 1, 19, 50)
   const expectedResolveDate = new Date()
   let incidentRepositorySaveSpy: any
   const expectedIncidentId = '1234'
@@ -22,10 +23,9 @@ describe('View Incident Details', () => {
     department: 'some department',
     description: 'some description',
     category: 'some category',
-    categoryItem: 'some category item',
     status: 'reported',
     reportedBy: 'some user id',
-    reportedOn: expectedDate.toISOString(),
+    reportedOn: reportedDate.toISOString(),
     date: expectedDate.toISOString(),
   } as Incident
 
@@ -52,74 +52,126 @@ describe('View Incident Details', () => {
     return { ...renderResults, history }
   }
 
-  test('type into department field', async () => {
-    setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
+  describe('view details', () => {
+    it('should render the date of the incident', async () => {
+      setup(expectedIncident, [Permissions.ViewIncident])
+      expect(
+        await screen.findByRole('heading', {
+          name: /incidents\.reports\.dateofincident/i,
+        }),
+      ).toBeInTheDocument()
 
-    expect(
-      await screen.findByRole('textbox', { name: /incidents\.reports\.department/i }),
-    ).toBeInTheDocument()
-    expect(
-      await screen.findByRole('textbox', { name: /incidents\.reports\.department/i }),
-    ).not.toBeEnabled()
-  })
+      expect(
+        await screen.findByRole('heading', { name: /2020-06-01 07:48 PM/i }),
+      ).toBeInTheDocument()
+    })
 
-  test('type into category field', async () => {
-    setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
-    expect(
-      await screen.findByRole('textbox', {
-        name: /incidents\.reports\.category\b/i,
-      }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('textbox', {
-        name: /incidents\.reports\.category\b/i,
-      }),
-    ).not.toBeEnabled()
-  })
+    it('should render the status of the incident', async () => {
+      setup(expectedIncident, [Permissions.ViewIncident])
 
-  test('type into category item field', async () => {
-    setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
-    expect(
-      await screen.findByRole('textbox', {
-        name: /incidents\.reports\.categoryitem/i,
-      }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('textbox', {
-        name: /incidents\.reports\.categoryitem/i,
-      }),
-    ).not.toBeEnabled()
-  })
+      expect(
+        await screen.findByRole('heading', {
+          name: /incidents\.reports\.status/i,
+        }),
+      ).toBeInTheDocument()
 
-  test('type into description field', async () => {
-    setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
-    expect(
-      await screen.findByRole('textbox', {
-        name: /incidents\.reports\.description/i,
-      }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('textbox', {
-        name: /incidents\.reports\.description/i,
-      }),
-    ).not.toBeEnabled()
-  })
+      expect(await screen.findByRole('heading', { name: 'reported' })).toBeInTheDocument()
+    })
 
-  describe('on resolve', () => {
-    it('should mark the status as resolved and fill in the resolved date with the current time', async () => {
-      const { history } = setup(expectedIncident, [
-        Permissions.ViewIncident,
-        Permissions.ResolveIncident,
-      ])
+    it('should render who reported the incident', async () => {
+      setup(expectedIncident, [Permissions.ViewIncident])
 
-      const resolveButton = await screen.findByRole('button', {
-        name: /incidents\.reports\.resolve/i,
+      expect(
+        await screen.findByRole('heading', {
+          name: /incidents\.reports\.reportedby/i,
+        }),
+      ).toBeInTheDocument()
+
+      expect(await screen.findByRole('heading', { name: 'some user id' }))
+    })
+    it('should render the date the incident was reported', async () => {
+      setup(expectedIncident, [Permissions.ViewIncident])
+
+      expect(
+        await screen.findByRole('heading', {
+          name: /incidents\.reports\.reportedon/i,
+        }),
+      ).toBeInTheDocument()
+
+      expect(
+        await screen.findByRole('heading', { name: /2020-06-01 07:50 PM/i }),
+      ).toBeInTheDocument()
+    })
+    test('type into department field', async () => {
+      setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
+
+      expect(
+        await screen.findByRole('textbox', { name: /incidents\.reports\.department/i }),
+      ).toBeInTheDocument()
+      expect(
+        await screen.findByRole('textbox', { name: /incidents\.reports\.department/i }),
+      ).not.toBeEnabled()
+    })
+
+    test('type into category field', async () => {
+      setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
+
+      expect(
+        await screen.findByRole('textbox', {
+          name: /incidents\.reports\.category\b/i,
+        }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('textbox', {
+          name: /incidents\.reports\.category\b/i,
+        }),
+      ).not.toBeEnabled()
+    })
+
+    test('type into category item field', async () => {
+      setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
+      expect(
+        await screen.findByRole('textbox', {
+          name: /incidents\.reports\.categoryitem/i,
+        }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('textbox', {
+          name: /incidents\.reports\.categoryitem/i,
+        }),
+      ).not.toBeEnabled()
+    })
+
+    test('type into description field', async () => {
+      setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
+      expect(
+        await screen.findByRole('textbox', {
+          name: /incidents\.reports\.description/i,
+        }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('textbox', {
+          name: /incidents\.reports\.description/i,
+        }),
+      ).not.toBeEnabled()
+    })
+
+    describe('on resolve', () => {
+      it('should mark the status as resolved and fill in the resolved date with the current time', async () => {
+        const { history } = setup(expectedIncident, [
+          Permissions.ViewIncident,
+          Permissions.ResolveIncident,
+        ])
+
+        const resolveButton = await screen.findByRole('button', {
+          name: /incidents\.reports\.resolve/i,
+        })
+
+        userEvent.click(resolveButton)
+
+        await waitFor(() => expect(incidentRepositorySaveSpy).toHaveBeenCalledTimes(1))
+        expect(history.location.pathname).toEqual('/incidents')
       })
-
-      userEvent.click(resolveButton)
-
-      await waitFor(() => expect(incidentRepositorySaveSpy).toHaveBeenCalledTimes(1))
-      expect(history.location.pathname).toEqual('/incidents')
     })
   })
 })

--- a/src/__tests__/incidents/view/ViewIncidentDetails.test.tsx
+++ b/src/__tests__/incidents/view/ViewIncidentDetails.test.tsx
@@ -23,6 +23,7 @@ describe('View Incident Details', () => {
     department: 'some department',
     description: 'some description',
     category: 'some category',
+    categoryItem: 'some categoryItem',
     status: 'reported',
     reportedBy: 'some user id',
     reportedOn: reportedDate.toISOString(),
@@ -52,110 +53,115 @@ describe('View Incident Details', () => {
     return { ...renderResults, history }
   }
 
-  describe('view details', () => {
-    it('should render the date of the incident', async () => {
-      setup(expectedIncident, [Permissions.ViewIncident])
-      expect(
-        await screen.findByRole('heading', {
-          name: /incidents\.reports\.dateofincident/i,
-        }),
-      ).toBeInTheDocument()
+  describe('view incident details', () => {
+    describe('view incident details header', () => {
+      it('should render the date of the incident', async () => {
+        setup(expectedIncident, [Permissions.ViewIncident])
+        expect(
+          await screen.findByRole('heading', {
+            name: /incidents\.reports\.dateofincident/i,
+          }),
+        ).toBeInTheDocument()
 
-      expect(
-        await screen.findByRole('heading', { name: /2020-06-01 07:48 PM/i }),
-      ).toBeInTheDocument()
+        expect(
+          await screen.findByRole('heading', { name: /2020-06-01 07:48 PM/i }),
+        ).toBeInTheDocument()
+      })
+
+      it('should render the status of the incident', async () => {
+        setup(expectedIncident, [Permissions.ViewIncident])
+
+        expect(
+          await screen.findByRole('heading', {
+            name: /incidents\.reports\.status/i,
+          }),
+        ).toBeInTheDocument()
+
+        expect(await screen.findByRole('heading', { name: 'reported' })).toBeInTheDocument()
+      })
+
+      it('should render who reported the incident', async () => {
+        setup(expectedIncident, [Permissions.ViewIncident])
+
+        expect(
+          await screen.findByRole('heading', {
+            name: /incidents\.reports\.reportedby/i,
+          }),
+        ).toBeInTheDocument()
+
+        expect(await screen.findByRole('heading', { name: 'some user id' }))
+      })
+      it('should render the date the incident was reported', async () => {
+        setup(expectedIncident, [Permissions.ViewIncident])
+
+        expect(
+          await screen.findByRole('heading', {
+            name: /incidents\.reports\.reportedon/i,
+          }),
+        ).toBeInTheDocument()
+
+        expect(
+          await screen.findByRole('heading', { name: /2020-06-01 07:50 PM/i }),
+        ).toBeInTheDocument()
+      })
     })
+    describe('form elements should not be editable', () => {
+      it('should render the department input with label and display value', async () => {
+        setup(expectedIncident, [Permissions.ViewIncident])
+        expect(await screen.findByText(/incidents\.reports\.department/i)).toBeInTheDocument()
 
-    it('should render the status of the incident', async () => {
-      setup(expectedIncident, [Permissions.ViewIncident])
+        expect(
+          await screen.findByRole('textbox', { name: /incidents\.reports\.department/i }),
+        ).not.toBeEnabled()
 
-      expect(
-        await screen.findByRole('heading', {
-          name: /incidents\.reports\.status/i,
-        }),
-      ).toBeInTheDocument()
+        expect(
+          await screen.findByRole('textbox', { name: /incidents\.reports\.department/i }),
+        ).toHaveDisplayValue('some department')
+      })
 
-      expect(await screen.findByRole('heading', { name: 'reported' })).toBeInTheDocument()
+      it('should render the category input with label and display value', async () => {
+        setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
+        expect(await screen.findByText(/incidents\.reports\.category$/i)).toBeInTheDocument()
+
+        expect(
+          await screen.findByRole('textbox', { name: /incidents\.reports\.category$/i }),
+        ).not.toBeEnabled()
+
+        expect(
+          await screen.findByRole('textbox', { name: /incidents\.reports\.category$/i }),
+        ).toHaveDisplayValue('some category')
+      })
+      it('should render the categoryItem input with label and display value', async () => {
+        setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
+        expect(await screen.findByText(/incidents\.reports\.categoryItem$/i)).toBeInTheDocument()
+
+        expect(
+          await screen.findByRole('textbox', { name: /incidents\.reports\.categoryItem$/i }),
+        ).not.toBeEnabled()
+
+        expect(
+          await screen.findByRole('textbox', { name: /incidents\.reports\.categoryItem$/i }),
+        ).toHaveDisplayValue('some categoryItem')
+      })
+
+      it('should render the description input with label and display value', async () => {
+        setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
+        expect(
+          await screen.findByRole('textbox', {
+            name: /incidents\.reports\.description/i,
+          }),
+        ).toBeInTheDocument()
+        expect(
+          screen.getByRole('textbox', {
+            name: /incidents\.reports\.description/i,
+          }),
+        ).not.toBeEnabled()
+
+        expect(
+          await screen.findByRole('textbox', { name: /incidents\.reports\.description/i }),
+        ).toHaveDisplayValue('some description')
+      })
     })
-
-    it('should render who reported the incident', async () => {
-      setup(expectedIncident, [Permissions.ViewIncident])
-
-      expect(
-        await screen.findByRole('heading', {
-          name: /incidents\.reports\.reportedby/i,
-        }),
-      ).toBeInTheDocument()
-
-      expect(await screen.findByRole('heading', { name: 'some user id' }))
-    })
-    it('should render the date the incident was reported', async () => {
-      setup(expectedIncident, [Permissions.ViewIncident])
-
-      expect(
-        await screen.findByRole('heading', {
-          name: /incidents\.reports\.reportedon/i,
-        }),
-      ).toBeInTheDocument()
-
-      expect(
-        await screen.findByRole('heading', { name: /2020-06-01 07:50 PM/i }),
-      ).toBeInTheDocument()
-    })
-    test('type into department field', async () => {
-      setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
-
-      expect(
-        await screen.findByRole('textbox', { name: /incidents\.reports\.department/i }),
-      ).toBeInTheDocument()
-      expect(
-        await screen.findByRole('textbox', { name: /incidents\.reports\.department/i }),
-      ).not.toBeEnabled()
-    })
-
-    test('type into category field', async () => {
-      setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
-
-      expect(
-        await screen.findByRole('textbox', {
-          name: /incidents\.reports\.category\b/i,
-        }),
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole('textbox', {
-          name: /incidents\.reports\.category\b/i,
-        }),
-      ).not.toBeEnabled()
-    })
-
-    test('type into category item field', async () => {
-      setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
-      expect(
-        await screen.findByRole('textbox', {
-          name: /incidents\.reports\.categoryitem/i,
-        }),
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole('textbox', {
-          name: /incidents\.reports\.categoryitem/i,
-        }),
-      ).not.toBeEnabled()
-    })
-
-    test('type into description field', async () => {
-      setup(expectedIncident, [Permissions.ViewIncident, Permissions.ResolveIncident])
-      expect(
-        await screen.findByRole('textbox', {
-          name: /incidents\.reports\.description/i,
-        }),
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole('textbox', {
-          name: /incidents\.reports\.description/i,
-        }),
-      ).not.toBeEnabled()
-    })
-
     describe('on resolve', () => {
       it('should mark the status as resolved and fill in the resolved date with the current time', async () => {
         const { history } = setup(expectedIncident, [

--- a/src/__tests__/patients/diagnoses/AddDiagnosisModal.test.tsx
+++ b/src/__tests__/patients/diagnoses/AddDiagnosisModal.test.tsx
@@ -86,6 +86,7 @@ describe('Add Diagnosis Modal', () => {
         diagnoses: [expect.objectContaining({ name: 'yellow polka dot spots' })],
       }),
     )
+    expect(await screen.queryByRole('dialogue')).not.toBeInTheDocument()
   })
 
   it('should call the on close function when the cancel button is clicked', async () => {

--- a/src/__tests__/patients/edit/EditPatient.test.tsx
+++ b/src/__tests__/patients/edit/EditPatient.test.tsx
@@ -18,21 +18,21 @@ const mockStore = createMockStore<RootState, any>([thunk])
 
 const patient = {
   id: '123',
-  prefix: 'prefix',
-  givenName: 'givenName',
-  familyName: 'familyName',
-  suffix: 'suffix',
-  fullName: 'givenName familyName suffix',
+  prefix: 'Dr',
+  givenName: 'Bruce',
+  familyName: 'Banner',
+  suffix: 'MD',
+  fullName: 'Bruce Banner MD',
   sex: 'male',
   type: 'charity',
-  occupation: 'occupation',
-  preferredLanguage: 'preferredLanguage',
+  occupation: 'The Hulk',
+  preferredLanguage: 'Hulk lingo',
   phoneNumbers: [{ value: '123456789', id: '789' }],
-  emails: [{ value: 'email@email.com', id: '456' }],
+  emails: [{ value: 'theHulk@theAvengers.com', id: '456' }],
   addresses: [{ value: 'address', id: '123' }],
   code: 'P00001',
   dateOfBirth: subDays(new Date(), 2).toISOString(),
-  index: 'givenName familyName suffixP00001',
+  index: 'Bruce Banner MDP00001',
 } as Patient
 
 const setup = () => {
@@ -76,6 +76,8 @@ describe('Edit Patient', () => {
     await waitFor(() => {
       expect(PatientRepository.find).toHaveBeenCalledWith(patient.id)
     })
+
+    expect(screen.getByPlaceholderText(/patient.givenName/i)).toHaveValue(patient.givenName)
   })
 
   it('should dispatch updatePatient when save button is clicked', async () => {


### PR DESCRIPTION
fixes #250

Also changed expected patient info to make reading dom output easier when testing.  in `editPatient`