### PR TITLE
feat: add testids to inputs whose labels are not properly connected

### DIFF
--- a/src/shared/components/input/DatePickerWithLabelFormGroup.tsx
+++ b/src/shared/components/input/DatePickerWithLabelFormGroup.tsx
@@ -27,7 +27,7 @@ const DatePickerWithLabelFormGroup = (props: Props) => {
   } = props
   const id = `${name}DatePicker`
   return (
-    <div className="form-group">
+    <div className="form-group" data-testid={id}>
       <Label text={label} htmlFor={id} isRequired={isRequired} />
       <DateTimePicker
         dateFormat="MM/dd/yyyy"

--- a/src/shared/components/input/DateTimePickerWithLabelFormGroup.tsx
+++ b/src/shared/components/input/DateTimePickerWithLabelFormGroup.tsx
@@ -16,7 +16,7 @@ const DateTimePickerWithLabelFormGroup = (props: Props) => {
   const { onChange, label, name, isEditable, value, isRequired, feedback, isInvalid } = props
   const id = `${name}DateTimePicker`
   return (
-    <div className="form-group">
+    <div className="form-group" data-testid={id}>
       <Label text={label} isRequired={isRequired} htmlFor={id} />
       <DateTimePicker
         dateFormat="MM/dd/yyyy h:mm aa"

--- a/src/shared/components/input/SelectWithLabelFormGroup.tsx
+++ b/src/shared/components/input/SelectWithLabelFormGroup.tsx
@@ -35,7 +35,7 @@ const SelectWithLabelFormGroup = (props: Props) => {
   } = props
   const id = `${name}Select`
   return (
-    <div className="form-group">
+    <div className="form-group" data-testid={id}>
       {label && <Label text={label} htmlFor={id} isRequired={isRequired} />}
       <Select
         id={id}

--- a/src/shared/components/input/TextFieldWithLabelFormGroup.tsx
+++ b/src/shared/components/input/TextFieldWithLabelFormGroup.tsx
@@ -20,7 +20,6 @@ const TextFieldWithLabelFormGroup = (props: Props) => {
       {label && <Label text={label} htmlFor={inputId} isRequired={isRequired} />}
       <TextField
         id={inputId}
-        data-testid={inputId}
         rows={4}
         value={value}
         disabled={!isEditable}


### PR DESCRIPTION
Add `data-testid` to the div that wraps their select and date picker inputs. Instead of:
```ts
screen.getByPlaceholderText('-- Choose --')
// or
screen.getAllByRole('combobox')[0]
screen.getAllByRole('combobox')[1]
```
this would allow us to do:
```ts
within(screen.getByTestId(COMPONENT_ID)).getByRole('combobox')
```
---

The component's id is used as the testid to avoid adding an extra prop on every input we want to target. Within the components they have customized the rendered id value per component:
```ts
// SelectWithLabelFormGroup
const id = `${name}Select`

// DatePickerWithLabelFormGroup
const id = `${name}DatePicker`

// DateTimePickerWithLabelFormGroup
const id = `${name}DateTimePicker`
```
Didn't add testids to `TextField/TextInput` components because they seem to reliably accessible via `*ByLabelText`.